### PR TITLE
Fixing version id to be 1.1.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "checkstyle4sbt"
 
 organization := "net.ruidoblanco"
 
-version := "0.0.2"
+version := "1.1.7"
 
 scalaVersion := "2.10.3"
 


### PR DESCRIPTION
Updating the build.sbt so that when you do 'sbt publish', the right version path is created.
